### PR TITLE
Insert block in sidekiq and handle system timeout and not ready error

### DIFF
--- a/app/models/cita_sync/persist.rb
+++ b/app/models/cita_sync/persist.rb
@@ -181,7 +181,7 @@ module CitaSync
         # current biggest block number in database
         last_block_number = SyncInfo.current_block_number || -1
         ((last_block_number + 1)..block_number).each do |num|
-          break if event_loop_queue.size >= 100 || default_queue.size >= 500
+          break if !Rails.env.test? && (event_loop_queue.size >= 100 || default_queue.size >= 500)
 
           hex_str = HexUtils.to_hex(num)
           SaveBlockWorker.perform_async(hex_str)

--- a/app/workers/save_block_worker.rb
+++ b/app/workers/save_block_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SaveBlockWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: "event_loop"
+
+  # @param hex_num_str [String] hex number
+  def perform(hex_num_str)
+    CitaSync::Persist.save_block(hex_num_str)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,4 +3,5 @@
 :pidfile: tmp/pids/sidekiq.pid
 :logfile: log/sidekiq.log
 :queues:
-  - [default, 1]
+  - [default, 2]
+  - [event_loop, 1]

--- a/spec/models/cita_sync/persist_spec.rb
+++ b/spec/models/cita_sync/persist_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe CitaSync::Api, type: :model do
     it "save blocks with transactions with exist block" do
       Sidekiq::Worker.clear_all
       CitaSync::Persist.save_block("0x0")
+      SyncInfo.current_block_number = 0
       CitaSync::Persist.save_blocks_with_infos
       Sidekiq::Worker.drain_all
       expect(Block.count).to eq 2


### PR DESCRIPTION
It will decrease the rate of block lost, while error in network, CITA node or insert to database, it will retry later.