### PR TITLE
Save tx and it's event logs in one db transaction

### DIFF
--- a/app/models/cita_sync/persist.rb
+++ b/app/models/cita_sync/persist.rb
@@ -3,9 +3,9 @@
 module CitaSync
   class Persist
 
-    class SystemTimeoutError < StandardError;
+    class SystemTimeoutError < StandardError
     end
-    class NotReadyError < StandardError;
+    class NotReadyError < StandardError
     end
 
     class << self
@@ -70,9 +70,9 @@ module CitaSync
 
         # handle error
         unless tx_error.nil? && receipt_error.nil?
-          handle_error("getTransaction", [hash], tx_error) unless tx_error.nil?
-          handle_error("getTransactionReceipt", [hash], error) unless receipt_error.nil?
-          return
+          tx_sync_error = handle_error("getTransaction", [hash], tx_error) unless tx_error.nil?
+          receipt_sync_error = handle_error("getTransactionReceipt", [hash], receipt_error) unless receipt_error.nil?
+          return [tx_sync_error, receipt_sync_error]
         end
 
         return if tx_result.nil? && receipt_result.nil?

--- a/app/models/cita_sync/persist.rb
+++ b/app/models/cita_sync/persist.rb
@@ -3,8 +3,10 @@
 module CitaSync
   class Persist
 
-    class SystemTimeoutError < StandardError; end
-    class NotReadyError < StandardError; end
+    class SystemTimeoutError < StandardError;
+    end
+    class NotReadyError < StandardError;
+    end
 
     class << self
       # get save blocks or not config
@@ -57,42 +59,59 @@ module CitaSync
       # @param hash [String] hash of transaction
       # @return [Transaction, SyncError] return SyncError if rpc return an error
       def save_transaction(hash)
-        data = CitaSync::Api.get_transaction(hash)
-        result = data["result"]
-        error = data["error"]
+        tx_data = CitaSync::Api.get_transaction(hash)
+        receipt_data = CitaSync::Api.get_transaction_receipt(hash)
+
+        tx_result = tx_data["result"]
+        tx_error = tx_data["error"]
+
+        receipt_result = receipt_data["result"]
+        receipt_error = receipt_data["error"]
 
         # handle error
-        return handle_error("getTransaction", [hash], error) unless error.nil?
-        return nil if result.nil?
+        unless tx_error.nil? && receipt_error.nil?
+          handle_error("getTransaction", [hash], tx_error) unless tx_error.nil?
+          handle_error("getTransactionReceipt", [hash], error) unless receipt_error.nil?
+          return
+        end
+
+        return if tx_result.nil? && receipt_result.nil?
 
         block = nil
-        block = Block.find_by(block_number: HexUtils.to_decimal(result["blockNumber"])) if save_blocks?
+        block = Block.find_by(block_number: HexUtils.to_decimal(tx_result["blockNumber"])) if save_blocks?
 
-        content = result["content"]
+        content = tx_result["content"]
         message = Message.new(content)
         transaction = Transaction.new(
-          cita_hash: result["hash"],
+          cita_hash: tx_result["hash"],
           content: content,
-          block_number: result["blockNumber"],
-          block_hash: result["blockHash"],
-          index: result["index"],
+          block_number: tx_result["blockNumber"],
+          block_hash: tx_result["blockHash"],
+          index: tx_result["index"],
           block: block,
           from: message.from,
           to: message.to,
           data: message.data,
           value: message.value,
           version: message.version,
-          chain_id: message.chain_id
+          chain_id: message.chain_id,
+          contract_address: receipt_result["contractAddress"],
+          quota_used: receipt_result["quotaUsed"] || receipt_result["gasUsed"],
+          error_message: receipt_result["errorMessage"]
         )
-        receipt_data = CitaSync::Api.get_transaction_receipt(hash)
-        receipt_result = receipt_data["result"]
-        unless receipt_result.nil?
-          transaction.contract_address = receipt_result["contractAddress"]
-          transaction.quota_used = receipt_result["quotaUsed"] || receipt_result["gasUsed"]
-          transaction.error_message = receipt_result["errorMessage"]
+
+        ApplicationRecord.transaction do
+          transaction.save!
+          receipt_result["logs"]&.each do |log|
+            transaction.event_logs.build(log.transform_keys { |key| key.to_s.underscore }.merge(block: block))
+          end
+          transaction.save!
         end
-        transaction.save!
-        SaveEventLogsWorker.perform_async(receipt_result["logs"]) unless receipt_result.nil?
+
+        transaction.event_logs.each do |el|
+          SaveErc20TransferWorker.perform_async(el.id)
+        end
+
         transaction
       end
 

--- a/spec/models/cita_sync/persist_spec.rb
+++ b/spec/models/cita_sync/persist_spec.rb
@@ -84,13 +84,14 @@ RSpec.describe CitaSync::Api, type: :model do
 
     it "with error params" do
       params = ["0x0"]
-      sync_error = CitaSync::Persist.save_transaction(*params)
+      tx_sync_error, receipt_sync_error = CitaSync::Persist.save_transaction(*params)
 
-      expect(sync_error.method).to eq "getTransaction"
-      expect(sync_error.params).to eq params
-      expect(sync_error.code).to eq transaction_params_error_code
-      expect(sync_error.message).to eq transaction_params_error_message
-      expect(sync_error.data).to be nil
+      expect(tx_sync_error.method).to eq "getTransaction"
+      expect(receipt_sync_error.method).to eq "getTransactionReceipt"
+      expect(tx_sync_error.params).to eq params
+      expect(tx_sync_error.code).to eq transaction_params_error_code
+      expect(tx_sync_error.message).to eq transaction_params_error_message
+      expect(tx_sync_error.data).to be nil
     end
   end
 

--- a/spec/supports/block_mock_support.rb
+++ b/spec/supports/block_mock_support.rb
@@ -279,6 +279,9 @@ module BlockMockSupport
     let(:mock_get_transaction_params_error) do
       stub_request_error_wrapper("getTransaction", ["0x0"], transaction_params_error)
     end
+    let(:mock_get_transaction_receipt_params_error) do
+      stub_request_error_wrapper("getTransactionReceipt", ["0x0"], transaction_params_error)
+    end
 
     let(:transaction_receipt_result) do
       {
@@ -375,6 +378,7 @@ module BlockMockSupport
       mock_get_block_by_number_version1
       mock_get_transaction
       mock_get_transaction_params_error
+      mock_get_transaction_receipt_params_error
       mock_get_transaction_receipt
       mock_get_transaction_two
       mock_get_transaction_receipt_two


### PR DESCRIPTION
1. Must already get the transaction and it's receipt data before save it.
2. Save tx and it's event logs in one transaction.