### PR TITLE
Using `push_bulk` to push a list of workers, it performs better

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'redis-objects', '~> 1.4', '>= 1.4.3'
 
 # Sidekiq
 gem 'sidekiq', '~> 5.2', '>= 5.2.3'
+gem 'sidekiq-bulk', '~> 0.2.0'
 
 # Deployment
 gem 'mina', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,8 @@ GEM
       connection_pool (~> 2.2, >= 2.2.2)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq-bulk (0.2.0)
+      sidekiq
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -331,6 +333,7 @@ DEPENDENCIES
   rspec-rails (~> 3.7)
   rubocop (~> 0.59)
   sidekiq (~> 5.2, >= 5.2.3)
+  sidekiq-bulk (~> 0.2.0)
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
A wrapper of `Sidekiq::Client.push_bulk("class" => FooJob, "args" => [[1], [2], [3]])`, it will perform better than

```ruby
big_array.each do |e|
  FooJob.perform_async(e)
end
```