### PR TITLE
Fixed ERROR: In file ./.env: environment variable name 'LOOP_INTERVAL ' may…

### DIFF
--- a/.env
+++ b/.env
@@ -36,4 +36,4 @@ CITA_WS_PROTOCOL=""
 # block config
 SAVE_BLOCKS="true" # true or false, only "false" will not save blocks.
 
-LOOP_INTERVAL = "1"
+LOOP_INTERVAL="1"


### PR DESCRIPTION
… not contains whitespace.