### PR TITLE
docs: fix typo in API_DOC.md file

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -159,7 +159,7 @@ Also Support camelCase.
 
 ### Transaction
 
-Get transactions list and paginate it.
+Get transactions info.
 
 > GET /api/transactions/:hash
 


### PR DESCRIPTION
docs: fix typo in API_DOC.md file